### PR TITLE
Add lyrics route to retrieve song lyrics

### DIFF
--- a/src/routes/lyrics.ts
+++ b/src/routes/lyrics.ts
@@ -1,0 +1,21 @@
+import { Hono } from 'hono'
+import axios from 'axios'
+
+const app = new Hono()
+
+//* INTRODUCTION
+var welcomeMessage = "Welcome to the Lyrics route! Use /lyrics/:artist/:title to get the lyrics of a song by artist and title.";
+app.get("/", (c) => {
+    return c.text(welcomeMessage)
+})
+
+//* LYRICS
+app.get("/lyrics/:artist/:title", async (c) => {
+    var artist = c.req.param("artist")
+    var title = c.req.param("title")
+    var result = await axios.get(`https://api.lyrics.ovh/v1/${artist}/${title}`)
+    var lyrics = result.data
+    return c.json(lyrics)
+})
+
+export default app;


### PR DESCRIPTION
###  New Feature: Lyrics Route

This update introduces a new feature to our application - a lyrics route. 

You can now retrieve the lyrics of a song by specifying the artist and title in the URL. The route is defined as `/lyrics/:artist/:title`.

The lyrics are fetched from the `api.lyrics.ovh` API. 

The lyrics data is then returned as a JSON response. 
