### PR TITLE
Random User Generator API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ import lyrics from "./routes/lyrics";
 import jsonplaceholder from "./routes/jsonplaceholder";
 import bible from "./routes/bible";
 import restcountries from "./routes/restcountries";
+import randomUser from "./routes/randomuser";
 
 //* ENDPOINTS
 app.route('/github', github) // GitHub
@@ -43,6 +44,7 @@ app.route('/lyrics', lyrics) // Lyrics
 app.route('/jsonplaceholder', jsonplaceholder) // JSON Placeholder
 app.route('/bible',bible) // Bible
 app.route('/restcountries', restcountries) // REST Countries
+app.route('/randomuser', randomUser) // Random User
 
 
 //* ERROR HANDLING

--- a/src/routes/randomuser.ts
+++ b/src/routes/randomuser.ts
@@ -1,0 +1,77 @@
+import { Hono } from "hono";
+import axios from "axios";
+
+const app = new Hono();
+
+//* INTRODUCTION
+var welcomeMessage =
+  "Welcome to the RandomUser API route. Use /user to get a random user data.";
+app.get("/", (c) => {
+  return c.text(welcomeMessage);
+});
+
+//* Get Random user
+app.get("/user", async (c) => {
+  var result = await axios.get("https://randomuser.me/api/");
+  return c.json(result.data);
+});
+
+//* Get only random user data without seed, results, page, and version data.
+app.get("/user/data", async (c) => {
+  var result = await axios.get("https://randomuser.me/api/?noinfo");
+  return c.json(result.data);
+});
+
+//* Get multiple random users
+app.get("/users/:count", async (c) => {
+  var count = c.req.param("count");
+  var result = await axios.get(`https://randomuser.me/api/?results=${count}`);
+  return c.json(result.data);
+});
+
+//* Specific user by Gender
+app.get("/user/:gender", async (c) => {
+  var gender = c.req.param("gender");
+  var result = await axios.get(`https://randomuser.me/api?gender=${gender}`);
+  return c.json(result.data);
+});
+
+//* Specific user by Nationality
+app.get("/country/:nat", async (c) => {
+  var nat = c.req.param("nat");
+  var result = await axios.get(`https://randomuser.me/api?nat=${nat}`);
+  return c.json(result.data);
+});
+
+//* Exclude specific user data
+app.get("/exclude/:exclude", async (c) => {
+  var exclude = c.req.param("exclude");
+  var result = await axios.get(`https://randomuser.me/api/?exc=${exclude}`);
+  return c.json(result.data);
+});
+
+//* Include specific user data
+app.get("/include/:include", async (c) => {
+  var include = c.req.param("include");
+  var result = await axios.get(`https://randomuser.me/api/?inc=${include}`);
+  return c.json(result.data);
+});
+
+//* Specify data format
+app.get("/format/:format", async (c) => {
+  var format = c.req.param("format");
+  var result = await axios.get(`https://randomuser.me/api/?format=${format}`);
+  return c.json(result.data);
+});
+
+//* Specify password strength
+app.get("/password/:password", async (c) => {
+  var password = c.req.param("password");
+  var result = await axios.get(
+    `https://randomuser.me/api/?password=${password}`
+  );
+  return c.json(result.data);
+});
+
+
+export default app;


### PR DESCRIPTION
Added new routes to the Random User API endpoint for retrieving random user data based on various parameters.

Endpoints

- Fetch a single user data: /user
- Fetch random user data: /user/data
- Fetch multiple random users: /users/:count
- Fetch a random user by gender: /user/:gender
- Fetch a random user by nationality: /country/:nat
- Exclude specific user data fields: /exclude/:exclude
- Include specific user data fields: /include/:include
- Specify the data format: /format/:format
- Specify password strength: /password/:password

**Testing** 
Tested all routes locally to ensure proper functionality.